### PR TITLE
fix(entrypoint): add debug logging for script arguments in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,9 +54,14 @@ else
   echo "REDIS_URL not set, queue mode may fail."
 fi
 
+# Debug: Show all arguments received
+echo "DEBUG: Script arguments: \$0='$0' \$1='$1' \$2='$2' \$#='$#'"
+echo "DEBUG: All arguments: $@"
+
 # Determine command based on process type or argument
 if [ -n "$1" ]; then
   CMD="$1"
+  echo "Command received: '$CMD'"
 else
   # Default to 'start' for web dyno if no argument
   CMD="start"


### PR DESCRIPTION
- Introduced debug echo statements to display received script arguments for better traceability during execution.
- Enhanced visibility of the command being processed when an argument is provided.