### PR TITLE
fix(entrypoint): add concurrency settings for n8n worker process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,10 @@ if [ -n "${REDIS_URL+x}" ]; then
   export EXECUTIONS_MODE="queue"
   export QUEUE_BULL_REDIS_URL="${REDIS_URL}"
   
+  # Set worker concurrency (default is 10 per worker)
+  export N8N_CONCURRENCY="${N8N_CONCURRENCY:-20}"
+  export QUEUE_BULL_REDIS_CONCURRENCY="${QUEUE_BULL_REDIS_CONCURRENCY:-20}"
+  
   # Additional debugging and connection settings
   echo "DEBUG: Final Redis configuration:"
   echo "  REDIS_URL: ${REDIS_URL}"
@@ -94,6 +98,8 @@ if [ -n "${REDIS_URL+x}" ]; then
   echo "  QUEUE_BULL_REDIS_URL: ${QUEUE_BULL_REDIS_URL}"
   echo "  N8N_REDIS_URL: ${N8N_REDIS_URL}"
   echo "  EXECUTIONS_MODE: ${EXECUTIONS_MODE}"
+  echo "  N8N_CONCURRENCY: ${N8N_CONCURRENCY}"
+  echo "  QUEUE_BULL_REDIS_CONCURRENCY: ${QUEUE_BULL_REDIS_CONCURRENCY}"
   
   echo "Redis SSL configuration applied for ioredis compatibility"
 else
@@ -131,8 +137,8 @@ case "$CMD" in
     n8n start
     ;;
   worker)
-    echo "Starting n8n worker process"
-    n8n worker
+    echo "Starting n8n worker process with concurrency: ${N8N_CONCURRENCY:-10}"
+    n8n worker --concurrency=${N8N_CONCURRENCY:-20}
     ;;
   *)
     echo "Unknown command: '$CMD'. Use 'start' or 'worker'."


### PR DESCRIPTION
- Introduced N8N_CONCURRENCY and QUEUE_BULL_REDIS_CONCURRENCY environment variables to set worker concurrency, defaulting to 20.
- Updated debug logging to include concurrency settings for better visibility during execution.
- Ensured compatibility with existing Redis configuration while enhancing worker performance.